### PR TITLE
Ability to have specific middleware for specific resource controllers

### DIFF
--- a/resource-router-middleware.js
+++ b/resource-router-middleware.js
@@ -1,6 +1,6 @@
 var Router = require('express').Router;
 
-var keyed = ['get', 'read', 'put', 'patch', 'update', 'del', 'delete'],
+var keyed = ['get', 'read', 'put', 'update', 'patch', 'modify', 'del', 'delete'],
 	map = { index:'get', list:'get', read:'get', create:'post', update:'put', modify:'patch' };
 
 module.exports = function ResourceRouter(route) {

--- a/resource-router-middleware.js
+++ b/resource-router-middleware.js
@@ -1,6 +1,6 @@
 var Router = require('express').Router;
 
-var keyed = ['get', 'read', 'put', 'update', 'patch', 'modify', 'del', 'delete'],
+var keyed = ['get', 'read', 'put', 'patch', 'update', 'del', 'delete'],
 	map = { index:'get', list:'get', read:'get', create:'post', update:'put', modify:'patch' };
 
 module.exports = function ResourceRouter(route) {
@@ -24,7 +24,9 @@ module.exports = function ResourceRouter(route) {
 		fn = map[key] || key;
 		if (typeof router[fn]==='function') {
 			url = ~keyed.indexOf(key) ? ('/:'+route.id) : '/';
-			router[fn](url, route[key]);
+			var controller = route[key].controller ? route[key].controller : route[key];
+			var middleware = route[key].middleware ? route[key].middleware : [];
+			router[fn](url, middleware, controller);
 		}
 	}
 


### PR DESCRIPTION
## Overview
Currently all the keys are just functions (ie. create, read). You can have a case where auth is required for creating a resource but not reading it. You can't add middleware to specific controllers. The old usage would still work, where create is a function.

Example: 
```
        create: {
		middleware: [],
		controller({ body }, res) {
			body.id = facets.length.toString(36);
			facets.push(body);
			res.json(body);
		}
	},
```