### PR TITLE
Avoid /:undefined when resource `id` is not defined

### DIFF
--- a/resource-router-middleware.js
+++ b/resource-router-middleware.js
@@ -23,7 +23,7 @@ module.exports = function ResourceRouter(route) {
 	for (key in route) {
 		fn = map[key] || key;
 		if (typeof router[fn]==='function') {
-			url = ~keyed.indexOf(key) ? ('/:'+route.id) : '/';
+			url = ~keyed.indexOf(key) && route.id ? ('/:'+route.id) : '/';
 			router[fn](url, route[key]);
 		}
 	}


### PR DESCRIPTION
Currently, when the `id` is undefined the router always defaults to `/:undefined` vs `/`

The latter result accounts for request methods without the need for the URI fragment.